### PR TITLE
Introduce kotlin coroutines flow

### DIFF
--- a/androidApp/build.gradle.kts
+++ b/androidApp/build.gradle.kts
@@ -27,7 +27,7 @@ android {
   }
 
   lintOptions {
-    setAbortOnError(false)
+    isAbortOnError = false
   }
   compileOptions {
     sourceCompatibility = JavaVersion.VERSION_1_8
@@ -46,14 +46,17 @@ dependencies {
   implementation(kotlin("stdlib-jdk7", KotlinCompilerVersion.VERSION))
   implementation(project(":shared"))
 
-  implementation("androidx.constraintlayout:constraintlayout:2.0.0-beta1")
-  implementation("androidx.appcompat:appcompat:1.0.2")
+  implementation("androidx.constraintlayout:constraintlayout:2.0.0-beta2")
+  implementation("androidx.appcompat:appcompat:1.1.0")
   implementation("androidx.recyclerview:recyclerview:1.0.0")
-  implementation("androidx.lifecycle:lifecycle-runtime:2.0.0")
-  implementation("androidx.lifecycle:lifecycle-extensions:2.0.0")
+  implementation("androidx.lifecycle:lifecycle-runtime:2.1.0")
+  implementation("androidx.lifecycle:lifecycle-extensions:2.1.0")
   implementation("com.github.pedrovgs:renderers:3.4.0")
-  implementation("com.squareup.okhttp3:okhttp:3.11.0")
+  implementation("com.squareup.okhttp3:okhttp:3.12.1")
   implementation("com.squareup.picasso:picasso:2.71828")
+
+  implementation("org.jetbrains.kotlinx:kotlinx-coroutines-core:1.3.1")
+  implementation("org.jetbrains.kotlinx:kotlinx-coroutines-android:1.3.1")
 
   testImplementation("junit:junit:4.12")
   androidTestImplementation("org.mockito:mockito-android:2.28.2")

--- a/androidApp/src/main/kotlin/com/karumi/gallery/app/MainActivity.kt
+++ b/androidApp/src/main/kotlin/com/karumi/gallery/app/MainActivity.kt
@@ -33,20 +33,29 @@ class MainActivity : AppCompatActivity(), PhotoListPresenter.View {
     presenter.detachView()
   }
 
-  override fun showLoader() {
+  override fun render(state: PhotoListPresenter.View.State) {
+    when (state) {
+      is PhotoListPresenter.View.State.Loading -> renderLoading()
+      is PhotoListPresenter.View.State.Error -> renderError()
+      is PhotoListPresenter.View.State.Success -> renderPhotos(state.photos)
+    }
+  }
+
+  private fun renderLoading() {
     progress.visibility = View.VISIBLE
+    errorInformation.visibility = View.GONE
   }
 
-  override fun hideLoader() {
+  private fun renderError() {
     progress.visibility = View.GONE
-  }
-
-  override fun onLoadError() {
     errorInformation.visibility = View.VISIBLE
   }
 
-  override fun plusAssign(shots: List<PhotoShot>) {
-    val items = shots.map { PhotoItem(it.id, it.thumbnailUrl, it.authorName) }
+  private fun renderPhotos(photos: List<PhotoShot>) {
+    progress.visibility = View.GONE
+    errorInformation.visibility = View.GONE
+
+    val items = photos.map { PhotoItem(it.id, it.thumbnailUrl, it.authorName) }
     adapter.addAll(items)
     adapter.notifyDataSetChanged()
   }

--- a/iosApp/PhotoGallery/PhotoCollectionViewCell.xib
+++ b/iosApp/PhotoGallery/PhotoCollectionViewCell.xib
@@ -1,28 +1,28 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="14460.31" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="14490.70" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
     <device id="retina4_7" orientation="portrait">
         <adaptation id="fullscreen"/>
     </device>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="14460.20"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="14490.49"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <objects>
         <placeholder placeholderIdentifier="IBFilesOwner" id="-1" userLabel="File's Owner"/>
         <placeholder placeholderIdentifier="IBFirstResponder" id="-2" customClass="UIResponder"/>
-        <collectionViewCell opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" reuseIdentifier="PhotoCollectionViewCellReuseIdentifier" id="Kvj-ya-9xL" customClass="PhotoCollectionViewCell" customModule="Dribbble_app" customModuleProvider="target">
+        <collectionViewCell opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" reuseIdentifier="PhotoCollectionViewCellReuseIdentifier" id="Kvj-ya-9xL" customClass="PhotoCollectionViewCell" customModule="PhotoGallery" customModuleProvider="target">
             <rect key="frame" x="0.0" y="0.0" width="220" height="204"/>
             <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
             <view key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" insetsLayoutMarginsFromSafeArea="NO">
                 <rect key="frame" x="0.0" y="0.0" width="220" height="204"/>
                 <autoresizingMask key="autoresizingMask"/>
                 <subviews>
-                    <imageView userInteractionEnabled="NO" contentMode="scaleToFill" horizontalHuggingPriority="251" verticalHuggingPriority="251" translatesAutoresizingMaskIntoConstraints="NO" id="eiD-pr-Gu4">
+                    <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFill" horizontalHuggingPriority="251" verticalHuggingPriority="251" translatesAutoresizingMaskIntoConstraints="NO" id="eiD-pr-Gu4">
                         <rect key="frame" x="0.0" y="0.0" width="220" height="188"/>
                     </imageView>
-                    <imageView userInteractionEnabled="NO" contentMode="scaleToFill" horizontalHuggingPriority="251" verticalHuggingPriority="251" translatesAutoresizingMaskIntoConstraints="NO" id="RoS-jn-q9a">
+                    <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFill" horizontalHuggingPriority="251" verticalHuggingPriority="251" translatesAutoresizingMaskIntoConstraints="NO" id="RoS-jn-q9a">
                         <rect key="frame" x="0.0" y="0.0" width="220" height="188"/>
                     </imageView>
                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="by Nick Slater" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="gqP-3L-qtE">

--- a/iosApp/PhotoGallery/PhotoListViewController.swift
+++ b/iosApp/PhotoGallery/PhotoListViewController.swift
@@ -23,23 +23,33 @@ class PhotoListViewController: UIViewController, PhotoListPresenterView {
         errorTextLabel.isHidden = true
     }
 
-    func plusAssign(shots: [PhotoShot]) {
-        let newItems = shots.map(PhotoListItem.init)
+    func render(state: PhotoListPresenterViewState) {
+        if state is PhotoListPresenterViewState.Loading {
+            renderLoading()
+        } else if state is PhotoListPresenterViewState.Error {
+            renderError()
+        } else if let state = state as? PhotoListPresenterViewState.Success {
+            render(photos: state.photos)
+        }
+    }
+
+    func renderLoading() {
+        loadingIndicator.startAnimating()
+        errorTextLabel.isHidden = true
+    }
+    
+    func renderError() {
+        loadingIndicator.isHidden = true
+        errorTextLabel.isHidden = false
+    }
+
+    func render(photos: [PhotoShot]) {
+        loadingIndicator.isHidden = true
+        errorTextLabel.isHidden = true
+
+        let newItems = photos.map(PhotoListItem.init)
         items.append(contentsOf: newItems)
         allItemsCollectionView.reloadData()
-    }
-    
-    func showLoader() {
-        loadingIndicator.startAnimating()
-    }
-    
-    func hideLoader() {
-        loadingIndicator.stopAnimating()
-        loadingIndicator.isHidden = true
-    }
-    
-    func onLoadError() {
-        errorTextLabel.isHidden = false
     }
 }
 

--- a/shared/build.gradle
+++ b/shared/build.gradle
@@ -31,6 +31,9 @@ kotlin {
         all {
             languageSettings {
                 useExperimentalAnnotation('kotlin.Experimental')
+                useExperimentalAnnotation('kotlin.time.ExperimentalTime')
+                useExperimentalAnnotation('kotlinx.coroutines.FlowPreview')
+                useExperimentalAnnotation('kotlinx.coroutines.ExperimentalCoroutinesApi')
             }
         }
         commonMain {
@@ -57,7 +60,6 @@ kotlin {
         androidMain {
             dependencies {
                 implementation "org.jetbrains.kotlin:kotlin-stdlib:$kotlin_version"
-                implementation "org.jetbrains.kotlinx:kotlinx-coroutines-core:$coroutines_version"
                 implementation "org.jetbrains.kotlinx:kotlinx-coroutines-android:$coroutines_version"
                 implementation "org.jetbrains.kotlinx:kotlinx-serialization-runtime:$serialization_version"
 

--- a/shared/build.gradle
+++ b/shared/build.gradle
@@ -45,6 +45,7 @@ kotlin {
 
                 implementation "io.ktor:ktor-client-core:$ktor_version"
                 implementation "io.ktor:ktor-client-json:$ktor_version"
+                implementation "io.ktor:ktor-client-logging:$ktor_version"
                 implementation "io.ktor:ktor-client-serialization:$ktor_version"
             }
         }
@@ -68,6 +69,7 @@ kotlin {
                 implementation "io.ktor:ktor-client-android:$ktor_version"
                 implementation "io.ktor:ktor-client-core-jvm:$ktor_version"
                 implementation "io.ktor:ktor-client-json-jvm:$ktor_version"
+                implementation "io.ktor:ktor-client-logging-jvm:$ktor_version"
                 implementation "io.ktor:ktor-client-serialization-jvm:$ktor_version"
             }
         }
@@ -89,6 +91,7 @@ kotlin {
                 implementation "io.ktor:ktor-client-ios:$ktor_version"
                 implementation "io.ktor:ktor-client-core-native:$ktor_version"
                 implementation "io.ktor:ktor-client-json-native:$ktor_version"
+                implementation "io.ktor:ktor-client-logging-native:$ktor_version"
                 implementation "io.ktor:ktor-client-serialization-native:$ktor_version"
             }
         }

--- a/shared/build.gradle
+++ b/shared/build.gradle
@@ -4,8 +4,8 @@ group 'com.karumi'
 version '0.0.1'
 
 apply plugin: "kotlin-multiplatform"
-apply plugin: 'com.android.library'
 apply plugin: "kotlinx-serialization"
+apply plugin: 'com.android.library'
 apply plugin: "io.gitlab.arturbosch.detekt"
 apply plugin: "org.jlleitschuh.gradle.ktlint"
 
@@ -38,7 +38,8 @@ kotlin {
         }
         commonMain {
             dependencies {
-                implementation "org.jetbrains.kotlin:kotlin-stdlib-common:$kotlin_version"
+                implementation 'org.jetbrains.kotlin:kotlin-stdlib'
+
                 implementation "org.jetbrains.kotlinx:kotlinx-coroutines-core-common:$coroutines_version"
                 implementation "org.jetbrains.kotlinx:kotlinx-serialization-runtime-common:$serialization_version"
 
@@ -51,15 +52,16 @@ kotlin {
             dependencies {
                 implementation "org.jetbrains.kotlin:kotlin-test-common:$kotlin_version"
                 implementation "org.jetbrains.kotlin:kotlin-test-annotations-common:$kotlin_version"
-                implementation "org.jetbrains.kotlinx:kotlinx-coroutines-core-common:$coroutines_version"
 
-                //implementation "io.ktor:ktor-client-mock-native:$ktor_version"
+                implementation "org.jetbrains.kotlinx:kotlinx-coroutines-core:$coroutines_version"
+
                 api "io.ktor:ktor-client-mock:$ktor_version"
             }
         }
         androidMain {
             dependencies {
                 implementation "org.jetbrains.kotlin:kotlin-stdlib:$kotlin_version"
+
                 implementation "org.jetbrains.kotlinx:kotlinx-coroutines-android:$coroutines_version"
                 implementation "org.jetbrains.kotlinx:kotlinx-serialization-runtime:$serialization_version"
 
@@ -73,12 +75,10 @@ kotlin {
             dependencies {
                 implementation "org.jetbrains.kotlin:kotlin-test-junit:$kotlin_version"
 
-                implementation "io.ktor:ktor-client-mock-jvm:$ktor_version"
+                implementation "org.jetbrains.kotlinx:kotlinx-coroutines-core:$coroutines_version"
+                implementation "org.jetbrains.kotlinx:kotlinx-coroutines-android:$coroutines_version"
 
-                // TODO below dependencies can be removed after KT-29343 is fixed
-                implementation "io.ktor:ktor-client-core-jvm:$ktor_version"
-                implementation "io.ktor:ktor-client-json-jvm:$ktor_version"
-                implementation "io.ktor:ktor-client-serialization-jvm:$ktor_version"
+                implementation "io.ktor:ktor-client-mock-jvm:$ktor_version"
             }
         }
         iosMain {

--- a/shared/src/androidMain/kotlin/com/karumi/gallery/AndroidLogger.kt
+++ b/shared/src/androidMain/kotlin/com/karumi/gallery/AndroidLogger.kt
@@ -2,8 +2,8 @@ package com.karumi.gallery
 
 import android.util.Log
 
-actual fun logError(tag: String, message: String) {
-  Log.e(tag, message)
+actual fun logError(tag: String, message: String, error: Throwable?) {
+  Log.e(tag, message, error)
 }
 
 actual fun logInfo(tag: String, message: String) {

--- a/shared/src/androidMain/kotlin/com/karumi/gallery/app/androidAsync.kt
+++ b/shared/src/androidMain/kotlin/com/karumi/gallery/app/androidAsync.kt
@@ -3,6 +3,7 @@ package com.karumi.gallery.app
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.GlobalScope
+import kotlinx.coroutines.Job
 import kotlinx.coroutines.launch
 import kotlin.coroutines.CoroutineContext
 

--- a/shared/src/androidMain/kotlin/com/karumi/gallery/app/androidAsync.kt
+++ b/shared/src/androidMain/kotlin/com/karumi/gallery/app/androidAsync.kt
@@ -2,13 +2,15 @@ package com.karumi.gallery.app
 
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.GlobalScope
-import kotlinx.coroutines.Job
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.flowOn
 import kotlinx.coroutines.launch
 import kotlin.coroutines.CoroutineContext
 
-actual fun launchInMain(block: suspend CoroutineScope.() -> Unit) =
-  GlobalScope.launch(Dispatchers.Main) { block() }
+actual fun CoroutineScope.launchInMain(block: suspend CoroutineScope.() -> Unit) =
+  launch(Dispatchers.Main) { block() }
+
+actual fun <T> Flow<T>.flowOnBackground(): Flow<T> = flowOn(Dispatchers.Default)
 
 actual fun <T> runBlocking(context: CoroutineContext, block: suspend CoroutineScope.() -> T): T =
   kotlinx.coroutines.runBlocking(context, block)

--- a/shared/src/commonMain/kotlin/com/karumi/gallery/Logger.kt
+++ b/shared/src/commonMain/kotlin/com/karumi/gallery/Logger.kt
@@ -1,4 +1,4 @@
 package com.karumi.gallery
 
-expect fun logError(tag: String, message: String)
+expect fun logError(tag: String, message: String, error: Throwable? = null)
 expect fun logInfo(tag: String, message: String)

--- a/shared/src/commonMain/kotlin/com/karumi/gallery/app/GalleryInjector.kt
+++ b/shared/src/commonMain/kotlin/com/karumi/gallery/app/GalleryInjector.kt
@@ -2,6 +2,7 @@ package com.karumi.gallery.app
 
 import com.karumi.gallery.data.PhotosApiClient
 import com.karumi.gallery.data.getEngine
+import com.karumi.gallery.domain.PhotosFlow
 import com.karumi.gallery.generated.KotlinConfig
 import com.karumi.gallery.usecase.GetPhotos
 import kotlin.native.concurrent.ThreadLocal
@@ -24,5 +25,8 @@ open class InjectionModule {
     PhotosApiClient(getEngine(), KotlinConfig.UNPLASH_KEY)
 
   open fun getPhotos(): GetPhotos =
-    GetPhotos(getPhotosApiClient())
+    GetPhotos(getPhotosFlow())
+
+  open fun getPhotosFlow(): PhotosFlow =
+    PhotosFlow(getPhotosApiClient())
 }

--- a/shared/src/commonMain/kotlin/com/karumi/gallery/app/PhotoListPresenter.kt
+++ b/shared/src/commonMain/kotlin/com/karumi/gallery/app/PhotoListPresenter.kt
@@ -1,7 +1,5 @@
 package com.karumi.gallery.app
 
-import com.karumi.gallery.logError
-import com.karumi.gallery.logInfo
 import com.karumi.gallery.model.Photos
 import com.karumi.gallery.usecase.GetPhotos
 import kotlinx.coroutines.CoroutineScope
@@ -18,23 +16,14 @@ class PhotoListPresenter(
   override val coroutineContext: CoroutineContext
     get() = job
 
-  companion object {
-    private const val TAG = "PhotoListPresenter"
-  }
-
   private val job = Job()
 
   fun onCreate() = launchInMain {
     view.render(View.State.Loading)
     getAllPhotos()
       .flowOnBackground()
-      .catch {
-        view.render(View.State.Error)
-        logError(TAG, "Load photos error: ${it.message}")
-      }.collect {
-        view.render(View.State.Success(it))
-        logInfo(TAG, "${it.size} photos received")
-      }
+      .catch { view.render(View.State.Error) }
+      .collect { view.render(View.State.Success(it)) }
   }
 
   fun detachView() {

--- a/shared/src/commonMain/kotlin/com/karumi/gallery/app/async.kt
+++ b/shared/src/commonMain/kotlin/com/karumi/gallery/app/async.kt
@@ -2,10 +2,13 @@ package com.karumi.gallery.app
 
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Job
+import kotlinx.coroutines.flow.Flow
 import kotlin.coroutines.CoroutineContext
 import kotlin.coroutines.EmptyCoroutineContext
 
-expect fun launchInMain(block: suspend CoroutineScope.() -> Unit): Job
+expect fun CoroutineScope.launchInMain(block: suspend CoroutineScope.() -> Unit): Job
+
+expect fun <T> Flow<T>.flowOnBackground(): Flow<T>
 
 expect fun <T> runBlocking(
   context: CoroutineContext = EmptyCoroutineContext,

--- a/shared/src/commonMain/kotlin/com/karumi/gallery/data/PhotosApiClient.kt
+++ b/shared/src/commonMain/kotlin/com/karumi/gallery/data/PhotosApiClient.kt
@@ -6,6 +6,10 @@ import io.ktor.client.HttpClient
 import io.ktor.client.engine.HttpClientEngine
 import io.ktor.client.features.json.JsonFeature
 import io.ktor.client.features.json.serializer.KotlinxSerializer
+import io.ktor.client.features.logging.DEFAULT
+import io.ktor.client.features.logging.LogLevel
+import io.ktor.client.features.logging.Logger
+import io.ktor.client.features.logging.Logging
 import io.ktor.client.request.get
 import io.ktor.client.request.header
 import io.ktor.client.request.parameter
@@ -36,6 +40,10 @@ open class PhotosApiClient(
           setMapper(PhotoUrlsEntity::class, PhotoUrlsEntity.serializer())
           setMapper(PhotoEntity::class, PhotoEntity.serializer())
         }
+      }
+      install(Logging) {
+        logger = Logger.DEFAULT
+        level = LogLevel.BODY
       }
     }
   }

--- a/shared/src/commonMain/kotlin/com/karumi/gallery/data/entities.kt
+++ b/shared/src/commonMain/kotlin/com/karumi/gallery/data/entities.kt
@@ -12,6 +12,7 @@ data class PhotoEntity(
   val created_at: String,
   val urls: PhotoUrlsEntity,
   val description: String?,
+  val likes: Int,
   val user: UserEntity
 )
 
@@ -47,5 +48,6 @@ internal fun List<PhotoEntity>.toDomain(): Photos =
 internal fun PhotoEntity.toDomain(): PhotoShot = PhotoShot(
   id = id,
   authorName = user.name,
-  thumbnailUrl = urls.thumb
+  thumbnailUrl = urls.thumb,
+  numberOfLikes = likes
 )

--- a/shared/src/commonMain/kotlin/com/karumi/gallery/domain/PhotosFlow.kt
+++ b/shared/src/commonMain/kotlin/com/karumi/gallery/domain/PhotosFlow.kt
@@ -1,0 +1,32 @@
+package com.karumi.gallery.domain
+
+import com.karumi.gallery.data.PhotosApiClient
+import com.karumi.gallery.model.Photos
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.flow
+import kotlinx.coroutines.flow.map
+import kotlin.time.Duration
+import kotlin.time.seconds
+
+class PhotosFlow(private val photosApiClient: PhotosApiClient) {
+
+  private companion object {
+    val updateInterval = 5.seconds
+  }
+
+  suspend fun get(): Flow<Photos> =
+    timer(repeatEvery = updateInterval)
+      .map { photosApiClient.getPhotos() }
+}
+
+private fun timer(
+  delay: Duration = Duration.ZERO,
+  repeatEvery: Duration
+) = flow {
+  delay(delay.toLongMilliseconds())
+  while (true) {
+    emit(Unit)
+    delay(repeatEvery.toLongMilliseconds())
+  }
+}

--- a/shared/src/commonMain/kotlin/com/karumi/gallery/model/PhotoShot.kt
+++ b/shared/src/commonMain/kotlin/com/karumi/gallery/model/PhotoShot.kt
@@ -5,5 +5,6 @@ typealias Photos = List<PhotoShot>
 data class PhotoShot(
   val id: String,
   val thumbnailUrl: String,
-  val authorName: String
+  val authorName: String,
+  val numberOfLikes: Int
 )

--- a/shared/src/commonMain/kotlin/com/karumi/gallery/usecase/GetPhotos.kt
+++ b/shared/src/commonMain/kotlin/com/karumi/gallery/usecase/GetPhotos.kt
@@ -1,8 +1,9 @@
 package com.karumi.gallery.usecase
 
-import com.karumi.gallery.data.PhotosApiClient
+import com.karumi.gallery.domain.PhotosFlow
 import com.karumi.gallery.model.Photos
+import kotlinx.coroutines.flow.Flow
 
-class GetPhotos(private val photosApiClient: PhotosApiClient) {
-  suspend operator fun invoke(): Photos = photosApiClient.getPhotos()
+class GetPhotos(private val photosFlow: PhotosFlow) {
+  suspend operator fun invoke(): Flow<Photos> = photosFlow.get()
 }

--- a/shared/src/iosMain/kotlin/com/karumi/gallery/IOSLogger.kt
+++ b/shared/src/iosMain/kotlin/com/karumi/gallery/IOSLogger.kt
@@ -2,7 +2,7 @@ package com.karumi.gallery
 
 import platform.Foundation.NSLog
 
-actual fun logError(tag: String, message: String) {
+actual fun logError(tag: String, message: String, error: Throwable?) {
   NSLog("$tag: $message")
 }
 

--- a/shared/src/iosMain/kotlin/com/karumi/gallery/app/iosAsync.kt
+++ b/shared/src/iosMain/kotlin/com/karumi/gallery/app/iosAsync.kt
@@ -6,7 +6,6 @@ import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Delay
 import kotlinx.coroutines.DisposableHandle
-import kotlinx.coroutines.GlobalScope
 import kotlinx.coroutines.InternalCoroutinesApi
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.Runnable

--- a/shared/src/iosMain/kotlin/com/karumi/gallery/app/iosAsync.kt
+++ b/shared/src/iosMain/kotlin/com/karumi/gallery/app/iosAsync.kt
@@ -5,18 +5,22 @@ import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.GlobalScope
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.Runnable
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.flowOn
 import kotlinx.coroutines.launch
 import platform.darwin.dispatch_async
 import platform.darwin.dispatch_get_main_queue
 import kotlin.coroutines.CoroutineContext
 
-actual fun launchInMain(block: suspend CoroutineScope.() -> Unit): Job =
-  GlobalScope.launch(NsQueueDispatcher) { block() }
+actual fun CoroutineScope.launchInMain(block: suspend CoroutineScope.() -> Unit): Job =
+  GlobalScope.launch(MainDispatcher) { block() }
+
+actual fun <T> Flow<T>.flowOnBackground(): Flow<T> = flowOn(MainDispatcher)
 
 actual fun <T> runBlocking(context: CoroutineContext, block: suspend CoroutineScope.() -> T): T =
   kotlinx.coroutines.runBlocking(context, block)
 
-internal object NsQueueDispatcher : CoroutineDispatcher() {
+internal object MainDispatcher : CoroutineDispatcher() {
   override fun dispatch(context: CoroutineContext, block: Runnable) {
     dispatch_async(dispatch_get_main_queue()) {
       block.run()

--- a/shared/src/iosMain/kotlin/com/karumi/gallery/app/iosAsync.kt
+++ b/shared/src/iosMain/kotlin/com/karumi/gallery/app/iosAsync.kt
@@ -1,15 +1,23 @@
 package com.karumi.gallery.app
 
+import com.karumi.gallery.logError
+import kotlinx.coroutines.CancellableContinuation
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Delay
+import kotlinx.coroutines.DisposableHandle
 import kotlinx.coroutines.GlobalScope
+import kotlinx.coroutines.InternalCoroutinesApi
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.Runnable
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.flowOn
 import kotlinx.coroutines.launch
+import platform.darwin.DISPATCH_TIME_NOW
+import platform.darwin.dispatch_after
 import platform.darwin.dispatch_async
 import platform.darwin.dispatch_get_main_queue
+import platform.darwin.dispatch_time
 import kotlin.coroutines.CoroutineContext
 
 actual fun CoroutineScope.launchInMain(block: suspend CoroutineScope.() -> Unit): Job =
@@ -20,10 +28,58 @@ actual fun <T> Flow<T>.flowOnBackground(): Flow<T> = flowOn(MainDispatcher)
 actual fun <T> runBlocking(context: CoroutineContext, block: suspend CoroutineScope.() -> T): T =
   kotlinx.coroutines.runBlocking(context, block)
 
-internal object MainDispatcher : CoroutineDispatcher() {
+@UseExperimental(InternalCoroutinesApi::class)
+internal object MainDispatcher : CoroutineDispatcher(), Delay {
   override fun dispatch(context: CoroutineContext, block: Runnable) {
     dispatch_async(dispatch_get_main_queue()) {
       block.run()
     }
+  }
+
+  @InternalCoroutinesApi
+  override fun scheduleResumeAfterDelay(
+    timeMillis: Long,
+    continuation: CancellableContinuation<Unit>
+  ) {
+    dispatch_after(
+      dispatch_time(DISPATCH_TIME_NOW, timeMillis * 1_000_000),
+      dispatch_get_main_queue()
+    ) {
+      try {
+        with(continuation) {
+          resumeUndispatched(Unit)
+        }
+      } catch (err: Throwable) {
+        logError("UNCAUGHT", err.message ?: "", err)
+        throw err
+      }
+    }
+  }
+
+  @InternalCoroutinesApi
+  override fun invokeOnTimeout(timeMillis: Long, block: Runnable): DisposableHandle {
+    val handle = object : DisposableHandle {
+      var disposed = false
+        private set
+
+      override fun dispose() {
+        disposed = true
+      }
+    }
+    dispatch_after(
+      dispatch_time(DISPATCH_TIME_NOW, timeMillis * 1_000_000),
+      dispatch_get_main_queue()
+    ) {
+      try {
+        if (!handle.disposed) {
+          block.run()
+        }
+      } catch (err: Throwable) {
+        logError("UNCAUGHT", err.message ?: "", err)
+        throw err
+      }
+    }
+
+    return handle
   }
 }

--- a/shared/src/iosMain/kotlin/com/karumi/gallery/app/iosAsync.kt
+++ b/shared/src/iosMain/kotlin/com/karumi/gallery/app/iosAsync.kt
@@ -21,7 +21,7 @@ import platform.darwin.dispatch_time
 import kotlin.coroutines.CoroutineContext
 
 actual fun CoroutineScope.launchInMain(block: suspend CoroutineScope.() -> Unit): Job =
-  GlobalScope.launch(MainDispatcher) { block() }
+  launch(MainDispatcher) { block() }
 
 actual fun <T> Flow<T>.flowOnBackground(): Flow<T> = flowOn(MainDispatcher)
 


### PR DESCRIPTION
### :pushpin: References
* **Issue:** https://github.com/Karumi/outreach/issues/77

### :tophat: What is the goal?

To introduce [Flow](https://kotlin.github.io/kotlinx.coroutines/kotlinx-coroutines-core/kotlinx.coroutines.flow/-flow/) into the project. The approach is not the best one but we now know this is possible.

### :memo: How is it being implemented?

* Update some other dependencies I missed in #20 .
* Include kotlin coroutines lib in Android project. It was working before this PR because there was a known bug in the gradle plugin version we were using that was including it automatically for us.
* Refactor presenter/view communication by using a single `render` method and passing a sealed class. This is just an idea for the future I've been having for a while, doing so can make it way easier to test presenter+view interaction with the help of snapshot testing, it's not really needed for this project though.
* Change async actual implementations to use the current scope. This means we have structured concurrency instead of relying on global scopes. The presenter now implements CoroutineScope and once it's dismissed it will just cancel running jobs for us.
* Transform the only use case of the project into a Flow of images. It's a forced example but it's the easiest one to test flow in a multiplatform environment. The flow works by asking the API every 5 seconds for new images, in order to implement it I had to create a `timer` flow that returns a `Unit` value with a configurable interval.
* The use case now talks with the `PhotosFlow` instead of doing it with the API directly.
* Add an implementation of the `Delay` interface to the iOS Dispatcher. This let us call the `delay` function that we are using in the `timer` flow. The previous implementation would just stop whenever it found a delay, making the app useless in iOS. The new code has been extracted [from here](https://github.com/Kotlin/kotlinx.coroutines/issues/470#issuecomment-440080970).

### :boom: How can it be tested?

Automatically!